### PR TITLE
Handling spaces in filenames

### DIFF
--- a/vsi2tif/src/convert.py
+++ b/vsi2tif/src/convert.py
@@ -22,7 +22,7 @@ def cellsens2raw(
 
     cmd = (
         f"{bfconvert} -tilex {tz} -tiley {tz} -nogroup -no-upgrade -overwrite -bigtiff -series {plane} "
-        f"-compression {compression} \"{input_path}\" \"{output_path}\""
+        f'-compression {compression} "{input_path}" "{output_path}"'
     )
     try:
         run_wrapper(cmd=cmd, verbose=verbose, max_mem=max_mem)
@@ -37,7 +37,8 @@ def raw2tif(input_path: str, output_path: str, compression: str = "jpeg", qualit
     os.makedirs("/".join(output_path.split("/")[:-1]), exist_ok=True)
 
     cmd = (
-        f"vips tiffsave \"{input_path}\" \"{output_path}\" --bigtiff --tile --pyramid --compression={compression} --Q={quality}"
+        f'vips tiffsave "{input_path}" "{output_path}" --bigtiff --tile --pyramid --compression={compression}'
+        f" --Q={quality}"
     )
     try:
         run_wrapper(cmd=cmd, verbose=verbose)

--- a/vsi2tif/src/convert.py
+++ b/vsi2tif/src/convert.py
@@ -22,7 +22,7 @@ def cellsens2raw(
 
     cmd = (
         f"{bfconvert} -tilex {tz} -tiley {tz} -nogroup -no-upgrade -overwrite -bigtiff -series {plane} "
-        f"-compression {compression} {input_path} {output_path}"
+        f"-compression {compression} \"{input_path}\" \"{output_path}\""
     )
     try:
         run_wrapper(cmd=cmd, verbose=verbose, max_mem=max_mem)
@@ -37,7 +37,7 @@ def raw2tif(input_path: str, output_path: str, compression: str = "jpeg", qualit
     os.makedirs("/".join(output_path.split("/")[:-1]), exist_ok=True)
 
     cmd = (
-        f"vips tiffsave {input_path} {output_path} --bigtiff --tile --pyramid --compression={compression} --Q={quality}"
+        f"vips tiffsave \"{input_path}\" \"{output_path}\" --bigtiff --tile --pyramid --compression={compression} --Q={quality}"
     )
     try:
         run_wrapper(cmd=cmd, verbose=verbose)

--- a/vsi2tif/src/process.py
+++ b/vsi2tif/src/process.py
@@ -32,6 +32,7 @@ def cellsens2tif_batch(
     quality: int = 85,
     max_mem: int = 32,
     verbose: int = 1,
+    remove_name_spaces = False,
 ) -> None:
     # create directory if it does not exist
     os.makedirs(output_path, exist_ok=True)
@@ -48,7 +49,10 @@ def cellsens2tif_batch(
     # perform conversion in separate processes
     for root, file in tqdm(paths):
         curr_input_path = os.path.join(root, file)
-        curr_output_path = (output_path + "/" + curr_input_path.split(input_path)[-1]).replace(".vsi", ".tif")
+        if remove_name_spaces:
+            curr_output_path = (output_path + "/" + curr_input_path.split(input_path)[-1]).replace(' ', '_').replace(".vsi", ".tif")
+        else:
+            curr_output_path = (output_path + "/" + curr_input_path.split(input_path)[-1]).replace(".vsi", ".tif")
 
         try:
             cellsens2tif(

--- a/vsi2tif/src/process.py
+++ b/vsi2tif/src/process.py
@@ -32,7 +32,7 @@ def cellsens2tif_batch(
     quality: int = 85,
     max_mem: int = 32,
     verbose: int = 1,
-    remove_name_spaces = False,
+    remove_name_spaces=False,
 ) -> None:
     # create directory if it does not exist
     os.makedirs(output_path, exist_ok=True)
@@ -50,7 +50,9 @@ def cellsens2tif_batch(
     for root, file in tqdm(paths):
         curr_input_path = os.path.join(root, file)
         if remove_name_spaces:
-            curr_output_path = (output_path + "/" + curr_input_path.split(input_path)[-1]).replace(' ', '_').replace(".vsi", ".tif")
+            curr_output_path = (
+                (output_path + "/" + curr_input_path.split(input_path)[-1]).replace(" ", "_").replace(".vsi", ".tif")
+            )
         else:
             curr_output_path = (output_path + "/" + curr_input_path.split(input_path)[-1]).replace(".vsi", ".tif")
 

--- a/vsi2tif/vsi2tif.py
+++ b/vsi2tif/vsi2tif.py
@@ -17,7 +17,9 @@ def main():
     parser.add_argument("-q", "--quality", help="compression quality used with JPEG compression", default=85)
     parser.add_argument("-m", "--max-mem", help="set maximum memory in the java vm", default=32)
     parser.add_argument("-v", "--verbose", help="set verbosity level", default=1, type=int)
-    parser.add_argument("-rs", "--remove-name-spaces", help="replace spaces in filename with underscores in batch mode", default=False)
+    parser.add_argument(
+        "--remove-name-spaces", help="replace spaces in filename with underscores in batch mode", action="store_true"
+    )
     argv = parser.parse_args()
 
     if argv.verbose not in list(range(6)):
@@ -55,7 +57,7 @@ def main():
             argv.quality,
             argv.max_mem,
             argv.verbose,
-            argv.remove_name_spaces
+            argv.remove_name_spaces,
         )
 
 

--- a/vsi2tif/vsi2tif.py
+++ b/vsi2tif/vsi2tif.py
@@ -17,6 +17,7 @@ def main():
     parser.add_argument("-q", "--quality", help="compression quality used with JPEG compression", default=85)
     parser.add_argument("-m", "--max-mem", help="set maximum memory in the java vm", default=32)
     parser.add_argument("-v", "--verbose", help="set verbosity level", default=1, type=int)
+    parser.add_argument("-rs", "--remove-name-spaces", help="replace spaces in filename with underscores in batch mode", default=False)
     argv = parser.parse_args()
 
     if argv.verbose not in list(range(6)):
@@ -54,6 +55,7 @@ def main():
             argv.quality,
             argv.max_mem,
             argv.verbose,
+            argv.remove_name_spaces
         )
 
 


### PR DESCRIPTION
Preventing crash when suprocessing using filenames with spaces.
Flag to automatically replace spaces in destination filename (but not in path).

fixes #23 